### PR TITLE
🔥 Remove obsolete build steps

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,122 @@
+#### Describe your issue
+
+> Describe the issue or ask your question regarding this module.
+> Provide as much relevant information as you can. If you're not sure if something
+> is relevant or not, include it as well!
+> 
+> Logs and screenshots are very welcome!
+
+#### How can others reproduce the issue?
+
+> Describe how others can reproduce this issue as precisely as possible.
+> 
+> If you can't reproduce the issue, let us know what you tried!
+> 
+> You can remove this section if the issue isn't something reproducable
+> (for example for certain questions or feature requests).
+
+#### Possible solution
+
+> If you have a possible solution to this issue or an idea that might
+> help us to find one, describe it here. Let us know what you tried!
+>
+> You can remove this section if it'd be empty.
+
+#### What's your setup
+
+- OS (`Windows/OS X/Linux` + `version`):
+- Node (`node --version`):
+- NPM (`npm --version`):
+- Docker (`docker version --format '{{.Server.Version}}'`):
+
+> You can remove this section if it's irrelevant to the issue
+> (for example for certain questions or feature requests).
+
+#### Issue checklist
+
+Please check the boxes in this list after submitting your Issue:
+
+- [ ] I've checked if this issue already exists
+- [ ] I've included all the information that i think is relevant
+- [ ] I've added logs and/or screenshots (if applicable)
+- [ ] I've mentioned PRs and issues that relate to this one
+
+## Example
+
+<details>
+<summary>
+:warning: Before creating the issue, click here to expand and follow the guide.
+</summary>
+<br>
+  
+1. Be sure to fill out **every** topic presented in this template. 
+If a section is not valid or useful for your issue, feel free to remove it.
+
+2. Use the attached Checklist to make sure your issue contains all relevant information.
+
+3. Attach a label to your issue that reflects what your issue is all about.
+**When your issue concerns only a specific platform, be sure to attach the label for that platform!**
+
+4. Please use a fitting emoji at the beginning of your issue title.
+
+Example 1 - Report a bug:
+```md
+:bug: Something is not working properly
+```
+
+Example 2 - Report a performance issue:
+```md
+:zap: Something is slower than it should be
+```
+
+Example 3 - Report a package vulnerability or security issue:
+```md
+:lock: Package xy produces vulnerabilites
+```
+
+```md
+:lock: User XY has access to something he shouldn't have
+```
+
+Example 4 - Report missing test coverage: 
+```md
+:white_check_mark: Add tests for...
+```
+
+You can of course phrase your titles however you like.
+Just be sure they are short, to the point and convey the general idea of the issue you are experiencing.
+</details>
+
+## Emojis
+
+<details>
+<summary>
+Expand for a list of most used Emojis.
+</summary>
+<br>
+
+Please prefix your Issue with an Emoji.
+
+Ref: https://gitmoji.carloscuesta.me/
+
+| Description              | Glyphe               | Emoji  |
+|--------------------------|----------------------|--------|
+| Bugfix                   | `:bug:`              | 🐛     |
+| Fixing Security Issues   | `:lock:`             | 🔒     |
+| Configuration releated   | `:wrench:`           | 🔧     |
+| Cosmetic                 | `:lipstick:`         | 💄     |
+| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
+| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
+| Formatting               | `:art:`              | 🎨     |
+| Improving Performance    | `:zap:`              | ⚡️     |
+| Initial commit           | `:tada:`             | 🎉     |
+| Linter                   | `:rotating_light:`   | 🚨     |
+| Miscellaneous            | `:package:`          | 📦     |
+| New Feature              | `:sparkles:`         | ✨     |
+| Refactoring Code         | `:recycle:`          | ♻️     |
+| Releasing / Version tags | `:bookmark:`         | 🔖     |
+| Removing Stuff           | `:fire:`             | 🔥     |
+| Tests                    | `:white_check_mark:` | ✅     |
+| Work In Progress (WIP)   | `:construction:`     | 🚧     |
+
+</details>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,120 @@
+:tada: **Thanks for submitting this Pull Request**
+
+Please provide a list including your changes.
+
+To help us to create a meaningful Changelog, we agreed
+to use an emoji-based commit-style. Use the [Emojis](#emojis)
+we provided below.
+
+Fill out the following, provide reference to issues
+and this PR- we will use this as merge commit message-body
+and the title of this PR as commit-headline:
+
+---
+
+**Changes:**
+
+1. Change 1
+2. Change 2
+3. (...)
+
+
+**Issues:**
+
+Closes #Issue
+Closes #Issue
+Closes (...)
+
+PR: #PullRequest
+
+---
+
+See the [examples](#example) for inspiration.
+
+## How can others test the changes?
+
+> Describe how others can test your changes (you can remove this section for typo fixes etc.)
+
+## PR-Checklist
+
+Please check the boxes in this list after submitting your PR:
+
+- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
+- [x] I've tested **all** changes included in this PR.
+- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
+- [x] I've rebased the `develop` branch with my branch before finishing this PR.
+- [x] I've **summarized all changes** in a list above.
+- [x] I've mentioned all **PRs, which relate to this one**.
+- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).
+
+## Example
+
+<details>
+<summary>
+:warning: Before merging please click here to expand and follow the guide.
+</summary>
+<br>
+
+Please use `:twisted_rightwards_arrows:` at the beginning of your merge commit title.
+
+Example 1:
+
+<pre>
+<code>
+:twisted_rightwards_arrows: :bug: Fix Wrong Text Decoration at ...
+</code>
+</pre>
+
+To get your commit message, just copy the first part of this pull request.
+
+Example 2:
+<pre>
+<code>
+**Changes:**
+
+- Fixes Wrong Text Decoration at ...
+- Fixes some typos
+- ...
+
+**Issues:**
+
+Closes #NumberOfFixedIssue
+
+PR: #NumberOfThisPR
+</code>
+</pre>
+</details>
+
+## Emojis
+
+<details>
+<summary>
+Expand for a list of most used Emojis.
+</summary>
+<br>
+
+Please prefix your commit messages with an Emoji.
+
+Ref: https://gitmoji.carloscuesta.me/
+
+| Description              | Glyphe               | Emoji  |
+|--------------------------|----------------------|--------|
+| Bugfix                   | `:bug:`              | 🐛     |
+| Fixing Security Issues   | `:lock:`             | 🔒     |
+| Configuration releated   | `:wrench:`           | 🔧     |
+| Cosmetic                 | `:lipstick:`         | 💄     |
+| Dependencies Downgrade   | `:arrow_down:`       | ⬇️     |
+| Dependencies Upgrade     | `:arrow_up:`         | ⬆️     |
+| Formatting               | `:art:`              | 🎨     |
+| Improving Performance    | `:zap:`              | ⚡️      |
+| Initial commit           | `:tada:`             | 🎉     |
+| Linter                   | `:rotating_light:`   | 🚨     |
+| Miscellaneous            | `:package:`          | 📦     |
+| New Feature              | `:sparkles:`         | ✨     |
+| Refactoring Code         | `:recycle:`          | ♻️      |
+| Releasing / Version tags | `:bookmark:`         | 🔖     |
+| Removing Stuff           | `:fire:`             | 🔥     |
+| Tests                    | `:white_check_mark:` | ✅     |
+| Work In Progress (WIP)   | `:construction:`     | 🚧     |
+
+</details>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,8 +48,6 @@ pipeline {
       steps {
         sh('node --version')
         sh('npm run build')
-        sh('npm run build-schemas')
-        sh('npm run build-doc')
       }
     }
     stage('test') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/solutionexplorer.contracts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Global contracts for the SolutionExplorer",
   "main": "dist/amd/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
   "scripts": {
     "build": "gulp build",
     "prepare": "npm run build && npm run build-schemas && npm run build-doc",
-    "build-doc": "gulp doc",
-    "build-schemas": "gulp typescript-schema",
     "lint": "gulp lint",
     "test": "gulp test"
   },


### PR DESCRIPTION
**Changes:**

1. Remove npm scripts `build-schemas` and `build-doc`. 
    - These are currently causing some trouble on Jenkins, but are completely obsolete anyway.
2. Add templates for PRs and Issues.

PR: #2

## How can others test the changes?

The scripts `build-doc` and `build-schemas` should no longer be available. 
Also, Jenkins should no longer attempt to execute these steps.

Please check the boxes in this list after submitting your PR:

- [x] You can merge this PR **right now** (if not, please prefix the title with "WIP: ")
- [x] I've tested **all** changes included in this PR.
- [x] I've also reviewed this PR myself before submitting (e.g. for scrambled letters, typos, etc.).
- [x] I've rebased the `develop` branch with my branch before finishing this PR.
- [x] I've **summarized all changes** in a list above.
- [x] I've mentioned all **PRs, which relate to this one**.
- [x] I've prefixed my Pull Request title is according to [gitmoji guide](https://gitmoji.carloscuesta.me/).